### PR TITLE
Add ES modules exports

### DIFF
--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -21,7 +21,8 @@ gulp.task('default', gulp.series(
         taskCss,
         taskJsonGroups
     ),
-    taskJs,
+    taskJs("umd"),
+    taskJs("es"),
     gulp.parallel(
         taskJsonRules,
         taskMinJs

--- a/gulpfile.js/tasks/js.js
+++ b/gulpfile.js/tasks/js.js
@@ -9,20 +9,24 @@ const babel = require('rollup-plugin-babel');
 const copyright = require('../utils/copyright');
 const version = require('../utils/version');
 
-function js() {
-    return src(['./src/**/*.js', './build/**/*.js'])
-        .pipe(gulpRollup({
-            input: paths.js.index,
-            output: {
-                format: 'umd',
-                name: 'Typograf'
-            },
-            plugins: [babel()]
-        }))
-        .pipe(version())
-        .pipe(copyright())
-        .pipe(gulpRename('typograf.js'))
-        .pipe(dest(paths.dir.build));
+const formatPrefix = { umd: "", es: ".es" };
+
+function jsTask(format) {
+    return function js() {
+        return src(['./src/**/*.js', './build/**/*.js'])
+            .pipe(gulpRollup({
+                input: paths.js.index,
+                output: {
+                    format: format,
+                    name: 'Typograf'
+                },
+                plugins: [babel()]
+            }))
+            .pipe(version())
+            .pipe(copyright())
+            .pipe(gulpRename(`typograf${formatPrefix[format]}.js`))
+            .pipe(dest(paths.dir.build));
+    }
 }
 
-module.exports = js;
+module.exports = jsTask;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "url": "https://github.com/typograf/typograf"
   },
   "main": "dist/typograf.js",
+  "module": "dist/typograf.es.js",
+  "exports": {
+    "require": "dist/typograf.js",
+    "import": "dist/typograf.es.js"
+  },
   "homepage": "https://github.com/typograf",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Add new `typograf.es.js` export for ESM support. This enables tree-shaking which can omit unused code in the build step. 

One can check the improvements in [this repo](https://github.com/yacodes/typograf-esm-cjs). UMD build is **101Kb**, whereas ESM is **96.5Kb**. That's an improvement whatsoever.

Some resources about benefits of using ESM:
- [Публикация, доставка и установка современного JavaScript для ускорения работы приложений](https://web.dev/i18n/ru/publish-modern-javascript/);
- [Rolling (up) a multi module system (esm, cjs...) compatible npm library with TypeScript and Babel](https://dev.to/remshams/rolling-up-a-multi-module-system-esm-cjs-compatible-npm-library-with-typescript-and-babel-3gjg);
- [Tree-Shaking: A Reference Guide](https://www.smashingmagazine.com/2021/05/tree-shaking-reference-guide/).