### PR TITLE
Добавил импорт для чешского языка

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -5,6 +5,7 @@ import common from './common';
 import be from './be';
 import bg from './bg';
 import ca from './ca';
+import cs from './cs';
 import da from './da';
 import de from './de';
 import el from './el';
@@ -36,6 +37,7 @@ const data = [
     be,
     bg,
     ca,
+    cs,
     da,
     de,
     el,


### PR DESCRIPTION
В документации среди [локалей](https://github.com/typograf/typograf/blob/dev/docs/LOCALES.en-US.md) указан чешский язык, для него также подготовлен файл в `data`, но далее он не был импортирован для использования в `data/index.js`, что вызывало ошибку при попытке подключить `new Typograf({locale: 'cs'})`.

В этом пул-реквесте добавлено подключение чешского языка.