### PR TITLE
WIP: Add en-GB quotes to common/quotes list

### DIFF
--- a/src/data/common.js
+++ b/src/data/common.js
@@ -1,5 +1,5 @@
 export default {
     'common/char': 'a-z',
     'common/dash': '--?|‒|–|—', // --, &#8210, &ndash, &mdash
-    'common/quote': '«‹»›„“‟”"'
+    'common/quote': '«‹»›„“‘‟”’"'
 };

--- a/src/rules/common/punctuation/quote.en-GB.test.js
+++ b/src/rules/common/punctuation/quote.en-GB.test.js
@@ -17,3 +17,24 @@ typografRuleTest([
     ],
     {locale: 'en-GB'}
 ]);
+
+/**
+ * Check if en-GB single quotes can be changed to en-US ones.
+ */ 
+typografRuleTest([
+    'common/punctuation/quote', [
+        [
+            'One of the most famous phrases is ‘to be or not to be’.',
+            'One of the most famous phrases is “to be or not to be”.'
+        ],
+        [
+            '‘I have no special talent,’ Einstein. ‘I am only curious enough.’',
+            '“I have no special talent,” Einstein. “I am only curious enough.”'
+        ],
+        [
+            '‘I was reading “The Economics of the USA” yesterday,’ she replied to me.',
+            '“I was reading ‘The Economics of the USA’ yesterday,” she replied to me.'
+        ]
+    ],
+    {locale: 'en-US'}
+]);


### PR DESCRIPTION
After typographing the string with `en-GB` locale it is impossible to process quotes one more time.

Steps to reproduce:
1. Process a string with quotes with `en-GB` locale;
2. Process the result with any other locale;
3. `en-GB` quotes won't be processed.

This PR fixes the issue, but breaks a couple tests. I would like to get this fixed, but not sure where to look or the reasoning behind not adding the `en-GB` quotes to the `common/quote` in the first place. 

Looking forward to your reply!