### PR TITLE
Fix afterComma before quotes

### DIFF
--- a/src/rules/common/space/afterComma.test.ts
+++ b/src/rules/common/space/afterComma.test.ts
@@ -28,5 +28,21 @@ typografRuleTest(['common/space/afterComma', [
     [
         '2,A',
         '2, A'
+    ],
+    [
+        '«Hello world,» said Michael.',
+        '«Hello world,» said Michael.'
     ]
 ]]);
+typografRuleTest(['common/space/afterComma', [
+    [
+        '‘Hello world,’ said Michael.',
+        '‘Hello world,’ said Michael.'
+    ]
+], { locale: 'en-GB' }]);
+typografRuleTest(['common/space/afterComma', [
+    [
+        '“Hello world,” said Michael.',
+        '“Hello world,” said Michael.'
+    ]
+], { locale: 'en-US' }]);

--- a/src/rules/common/space/afterComma.ts
+++ b/src/rules/common/space/afterComma.ts
@@ -1,14 +1,15 @@
+import { DataQuote, DataCommonQuote } from '../../../data';
 import type { TypografRule } from '../../../main';
 import { privateLabel } from '../../../consts';
 import { isDigit } from '../../../helpers/regExp';
 
-const reComma = new RegExp('(.),([^)",:.?\\s\\/\\\\' + privateLabel + '])', 'g');
-
 export const afterCommaRule: TypografRule = {
     name: 'common/space/afterComma',
-    handler(text) {
+    handler(text, settings, context) {
+        const quote = context.getData('quote');
+        const quotes = typeof quote === 'string' ? quote as DataCommonQuote : (quote as DataQuote).right;
         return text.replace(
-            reComma,
+            new RegExp('(.),([^)",:.?\\s\\/\\\\' + privateLabel + quotes + '])', 'g'),
             ($0, $1, $2) => isDigit($1) && isDigit($2) ? $0 : $1 + ', ' + $2
         );
     }


### PR DESCRIPTION
Fixes adding unnecessary space after comma and before quote in several scenarios.

The bug can be reproduced within the fiddle: https://typograf.github.io/#!text=%E2%80%9CHello%20world%2C%E2%80%9D%20said%20Michael
```
“Hello world,” said Michael. → “Hello world, ” said Michael.
                                            ┬ 
space is unnecessary here ──────────────────┘
```