### PR TITLE
Предложение: добавить ссылку на плагин в ридми

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=rusnasonov.vscode-typograf)
   - [Bitrix](https://github.com/ilimurzin/bitrix-typograf)
   - [Markdown-it-typograf](https://github.com/ceigh/markdown-it-typograf)
+  - [Marked-typograf](https://github.com/laidrivm/marked-typograf)
 - [Поддерживаемые правила](./docs/RULES.ru.md)
 - API
   - [Включить или отключить правила](./docs/api_rules.md)


### PR DESCRIPTION
Привет!

Сделал небольшой плагин, чтобы подключать типограф к [marked](https://github.com/markedjs/marked). В реквесте добавляю ссылку на него в ридми.

Оффтоп. Когда писал кастомные правила для `queue: 'default'`, не хватало экспорта `privateLabel` и `privateSeparateLabel` — пришлось один из них хардкодить. Могу сделать реквест с их экспортом в `main.ts`, если это норм.